### PR TITLE
Fix PWA CORS issue with GitHub Pages URLs

### DIFF
--- a/js/globalUpdates.js
+++ b/js/globalUpdates.js
@@ -22,7 +22,7 @@ var update = {
 
             // If this is a master branch firmware, this will find a 404 as there is no tag tree. So default to master for docs.
             $.ajax({
-                url: bridge.proxy(globalSettings.docsTreeLocation + 'Settings.md'),
+                url: globalSettings.docsTreeLocation + 'Settings.md',
                 method: "HEAD",
                 statusCode: {
                     404: function () {

--- a/tabs/firmware_flasher.js
+++ b/tabs/firmware_flasher.js
@@ -212,7 +212,8 @@ TABS.firmware_flasher.initialize = function (callback) {
                         "releaseUrl": release.html_url,
                         "name"      : semver.clean(release.name),
                         "version"   : release.tag_name,
-                        "url"       : asset.browser_download_url,
+                        // Use GitHub Pages URL (has CORS headers) instead of GitHub Releases
+                        "url"       : `https://inavflight.github.io/firmware/${release.tag_name}/${asset.name}`,
                         "file"      : asset.name,
                         "raw_target": result.raw_target,
                         "target"    : result.target,
@@ -266,7 +267,8 @@ TABS.firmware_flasher.initialize = function (callback) {
                             "releaseUrl": release.html_url,
                             "name"      : semver.clean(release.name),
                             "version"   : release.tag_name,
-                            "url"       : asset.browser_download_url,
+                            // Use GitHub Pages URL (has CORS headers) instead of GitHub Releases
+                            "url"       : `https://inavflight.github.io/firmware/${release.tag_name}/${asset.name}`,
                             "file"      : asset.name,
                             "raw_target": result.raw_target,
                             "target"    : result.target,
@@ -503,10 +505,9 @@ TABS.firmware_flasher.initialize = function (callback) {
             if (summary) { // undefined while list is loading or while running offline
                 fileName = summary.file;
                 $(".load_remote_file").text(i18n.getMessage('firmwareFlasherButtonLoading')).addClass('disabled');
-                
-                const url = bridge.proxy(summary.url);
-                
-                $.get(url, function (data) {
+
+                // No proxy needed - GitHub Pages has CORS headers
+                $.get(summary.url, function (data) {
                     enable_load_online_button();
                     process_hex(data, summary);
                 }).fail(failed_to_load);


### PR DESCRIPTION
## Summary

Fixes the CORS issue preventing the PWA from downloading firmware hex files by switching from GitHub release URLs to GitHub Pages URLs.

## Problem

- GitHub release download URLs don't include CORS headers
- Browsers block cross-origin requests from the PWA
- Current workaround uses external proxy (`proxy.inav.workers.dev`)

## Solution

Use GitHub Pages URLs which automatically include CORS headers (`access-control-allow-origin: *`).

**URL Pattern Change:**
```
Before: https://github.com/iNavFlight/inav/releases/download/9.1.0/inav_9.1.0_MATEKF405.hex
After:  https://inavflight.github.io/firmware/9.1.0/inav_9.1.0_MATEKF405.hex
```

## Changes

- `tabs/firmware_flasher.js`: Updated firmware URL pattern for stable and dev releases, removed proxy wrapper
- `js/globalUpdates.js`: Removed proxy wrapper for documentation checks

## Requirements

Firmware hex files must be published to GitHub Pages at `firmware/{version}/` during the release process (CI/CD update needed separately).

## Benefits

- ✅ No external dependencies
- ✅ Free (GitHub Pages)
- ✅ Automatic CORS headers
- ✅ Works for both PWA and Electron